### PR TITLE
Specify Solidity compiler version

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -1,9 +1,14 @@
 require('babel-register')
 
 module.exports = {
+  compilers: {
+    solc: {
+      version: "^0.4.2",
+    }
+  },
   networks: {
     development: {
-      host: 'testrpc',
+      host: '127.0.0.1',
       port: 8545,
       network_id: '*' // Match any network id
     }


### PR DESCRIPTION
Specified compiler version into truffle.js. This avoids compilation error when compiling on newer Truffle versions. Also keeping the default host as 127.0.0.1 as 127.0.0.1:8545 is the default host + port combination from testrpc when running on a developer machine.